### PR TITLE
Add configurable authorization endpoint for the discovery handler

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -22,14 +22,15 @@ import (
 
 // Config is the config format for the main application.
 type Config struct {
-	Issuer    string    `json:"issuer"`
-	Storage   Storage   `json:"storage"`
-	Web       Web       `json:"web"`
-	Telemetry Telemetry `json:"telemetry"`
-	OAuth2    OAuth2    `json:"oauth2"`
-	GRPC      GRPC      `json:"grpc"`
-	Expiry    Expiry    `json:"expiry"`
-	Logger    Logger    `json:"logger"`
+	Issuer       string    `json:"issuer"`
+	AuthEndpoint string    `json:"authEndpoint"`
+	Storage      Storage   `json:"storage"`
+	Web          Web       `json:"web"`
+	Telemetry    Telemetry `json:"telemetry"`
+	OAuth2       OAuth2    `json:"oauth2"`
+	GRPC         GRPC      `json:"grpc"`
+	Expiry       Expiry    `json:"expiry"`
+	Logger       Logger    `json:"logger"`
 
 	Frontend server.WebConfig `json:"frontend"`
 

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -303,6 +304,13 @@ func runServe(options serveOptions) error {
 		}
 		logger.Infof("config device requests valid for: %v", deviceRequests)
 		serverConfig.DeviceRequestsValidFor = deviceRequests
+	}
+	if c.AuthEndpoint != "" {
+		_, err := url.Parse(c.AuthEndpoint)
+		if err != nil {
+			return fmt.Errorf("invalid config value %s for auth endpoint: %s", c.AuthEndpoint, err)
+		}
+		serverConfig.AuthEndpoint = c.AuthEndpoint
 	}
 	refreshTokenPolicy, err := server.NewRefreshTokenPolicy(
 		logger,

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -85,10 +85,16 @@ type discovery struct {
 	Claims            []string `json:"claims_supported"`
 }
 
-func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
+func (s *Server) discoveryHandler(c Config) (http.HandlerFunc, error) {
+	var authEndpoint string
+	if c.AuthEndpoint != "" {
+		authEndpoint = c.AuthEndpoint
+	} else {
+		authEndpoint = s.absURL("/auth")
+	}
 	d := discovery{
 		Issuer:            s.issuerURL.String(),
-		Auth:              s.absURL("/auth"),
+		Auth:              authEndpoint,
 		Token:             s.absURL("/token"),
 		Keys:              s.absURL("/keys"),
 		UserInfo:          s.absURL("/userinfo"),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -86,11 +86,9 @@ type discovery struct {
 }
 
 func (s *Server) discoveryHandler(c Config) (http.HandlerFunc, error) {
-	var authEndpoint string
+	authEndpoint := s.absURL("/auth")
 	if c.AuthEndpoint != "" {
 		authEndpoint = c.AuthEndpoint
-	} else {
-		authEndpoint = s.absURL("/auth")
 	}
 	d := discovery{
 		Issuer:            s.issuerURL.String(),

--- a/server/server.go
+++ b/server/server.go
@@ -61,6 +61,9 @@ type Connector struct {
 type Config struct {
 	Issuer string
 
+	// An optional override for the user facing authorization_url endpoint used in discovery
+	AuthEndpoint string
+
 	// The backing persistence layer.
 	Storage storage.Storage
 
@@ -329,7 +332,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	}
 	r.NotFoundHandler = http.NotFoundHandler()
 
-	discoveryHandler, err := s.discoveryHandler()
+	discoveryHandler, err := s.discoveryHandler(c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Our teleport instance's http server is accessible from two networking paths:
- at our issuer_url, staging.teleport-oidc.gns.square via envoy
- at our authorization_endpoint, teleport-oidc.stage.sqprod.co for users via trogdor.

User authentication from the browser needs to happen from trogdor, but all other communication must happen from envoy. This change introduces a configurable parameter that lets us set an authorization_endpoint that is different from the issuer_url.